### PR TITLE
Added mailhog to docker-compose

### DIFF
--- a/backend/src/main/java/com/adam/medipathbackend/controllers/UserController.java
+++ b/backend/src/main/java/com/adam/medipathbackend/controllers/UserController.java
@@ -96,7 +96,7 @@ public class UserController {
     @GetMapping("/resetpassword")
     public ResponseEntity<Map<String, Object>> resetPassword(@RequestParam(value = "address", required = false) String address) {
         if(address == null || address.isBlank()) {
-            return new ResponseEntity<>(Map.of("message", "missing email in request parameters"), HttpStatus.BAD_REQUEST);
+            return new ResponseEntity<>(Map.of("message", "missing address in request parameters"), HttpStatus.BAD_REQUEST);
         }
         Optional<User> u = userRepository.findByEmail(address);
         if(u.isPresent()) {

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -3,6 +3,5 @@ spring.data.mongodb.uri=mongodb://root:secret@medipath-mongodb-1:27017/admin
 spring.data.mongodb.database=medipath
 logging.level.org.springframework.data.mongodb.core.MongoTemplate=DEBUG
 spring.data.mongodb.auto-index-creation=true
-spring.mail.host=127.0.0.1
+spring.mail.host=mailhog
 spring.mail.port=1025
-spring.mail.protocol=smtp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,14 @@ services:
 
     networks:
       - web-network
+
+  mailhog:
+    image: 'mailhog/mailhog:latest'
+    ports:
+        - "8025:8025"
+        - "1025:1025"
+    networks:
+        - web-network
 networks:
   web-network:
     driver: bridge


### PR DESCRIPTION
### Changelog
- Added mailhog to docker-compose for password reset testing
- Changed the default configuration to use the mailhog container for handling SMTP
- Changed the error message in password resetting to clarify the "address" parameter is needed instead of "email"